### PR TITLE
fix: rename `is_valid_topology` to `matches_topology`

### DIFF
--- a/psdm/steadystate_case/case.py
+++ b/psdm/steadystate_case/case.py
@@ -30,7 +30,7 @@ class Case(Base):
     transformers: UniqueTuple[Transformer]
     external_grids: UniqueTuple[ExternalGrid]
 
-    def is_valid_topology(self, topology: Topology) -> bool:
+    def matches_topology(self, topology: Topology) -> bool:
         logger.info("Verifying steadystate case ...")
         if topology.meta != self.meta:
             logger.error("Metadata does not match.")

--- a/psdm/topology_case/case.py
+++ b/psdm/topology_case/case.py
@@ -26,7 +26,7 @@ class Case(Base):
     meta: Meta
     elements: UniqueTuple[ElementState]
 
-    def is_valid_topology(self, topology: Topology) -> bool:
+    def matches_topology(self, topology: Topology) -> bool:
         logger.info("Verifying topology case ...")
         if topology.meta != self.meta:
             logger.error("Metadata does not match.")


### PR DESCRIPTION
Fixes #129