### PR TITLE
build(deps): use dependency-groups in project.toml related to PEP 735

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@
   build-backend = "hatchling.build"
   requires      = ["hatchling"]
 
-[tool.uv]
-  dev-dependencies = [
+[dependency-groups]
+  dev = [
     "commitizen>=3.28.0",
     "ipykernel>=6.29.5",
     "mypy>=1.11.0",
@@ -35,6 +35,9 @@
     "ruff>=0.5.5",
   ]
 
+[tool.uv]
+  default-groups = ["dev"]
+  
 [tool.hatch.metadata]
   allow-direct-references = true
 


### PR DESCRIPTION
Fixes #169